### PR TITLE
rm proxy granting ticket block when no valid proxy to follow protocol

### DIFF
--- a/resources/routes.php
+++ b/resources/routes.php
@@ -16,9 +16,15 @@ Route::get('/login', '\Loren138\CASServer\Http\Controllers\CasController@getLogi
 Route::post('/login', '\Loren138\CASServer\Http\Controllers\CasController@postLogin');
 Route::get('/logout', '\Loren138\CASServer\Http\Controllers\CasController@getLogout');
 
+Route::get('/p3/login', '\Loren138\CASServer\Http\Controllers\CasController@getLogin');
+Route::post('/p3/login', '\Loren138\CASServer\Http\Controllers\CasController@postLogin');
+Route::get('/p3/logout', '\Loren138\CASServer\Http\Controllers\CasController@getLogout');
+
 // CAS 1.0 Validate
 Route::get('/validate', '\Loren138\CASServer\Http\Controllers\CasController@getValidate');
 // CAS 2.0 Validate
 Route::get('/serviceValidate', '\Loren138\CASServer\Http\Controllers\CasController@getServiceValidate');
+Route::get('/proxyValidate', '\Loren138\CASServer\Http\Controllers\CasController@getProxyValidate');
 // CAS 3.0 Validate
 Route::get('/p3/serviceValidate', '\Loren138\CASServer\Http\Controllers\CasController@getServiceValidate3');
+Route::get('/p3/proxyValidate', '\Loren138\CASServer\Http\Controllers\CasController@getProxyValidate3');

--- a/resources/xml/ticket_xml.blade.php
+++ b/resources/xml/ticket_xml.blade.php
@@ -17,8 +17,6 @@
         @endif
         @if ($serviceResponse['authenticationSuccess']['proxyGrantingTicket'])
             <cas:proxyGrantingTicket>{{$serviceResponse['authenticationSuccess']['proxyGrantingTicket']}}</cas:proxyGrantingTicket>
-        @else
-            <cas:proxyGrantingTicket/>
         @endif
     </cas:authenticationSuccess>
 @else

--- a/src/Http/Controllers/CasController.php
+++ b/src/Http/Controllers/CasController.php
@@ -179,6 +179,16 @@ class CasController extends Controller
         return $this->getServiceValidate3($request, $CASTicket, false);
     }
 
+    public function getProxyValidate(Request $request, CASTicket $CASTicket)
+    {
+        return $this->getServiceValidate3($request, $CASTicket, false);
+    }
+
+    public function getProxyValidate3(Request $request, CASTicket $CASTicket)
+    {
+        return $this->getServiceValidate3($request, $CASTicket, true);
+    }
+
     public function getLogout(Request $request, Service $service, CASAuthentication $CASAuthentication)
     {
         $CASAuthentication->logout();


### PR DESCRIPTION
From the documentation:
https://apereo.github.io/cas/5.2.x/protocol/CAS-Protocol-V2-Specification.html
"If the certificate fails validation, no proxy-granting ticket will be issued, and the CAS service response as described in Section 2.5.2 MUST NOT contain a <proxyGrantingTicket> block. "

I had to remove this from a view to get Canvas to authenticate.